### PR TITLE
Fix MySQL commit in voting app

### DIFF
--- a/voting/main.py
+++ b/voting/main.py
@@ -40,6 +40,7 @@ async def register_with_mysql(voter, candidate):
   with app.mysql.cursor() as cursor:
     sql = "INSERT INTO votes (candidate, voter) VALUES (%s, %s)"
     cursor.execute(sql, (candidate, voter))
+  app.mysql.commit()
 
 
 async def get_candidates_from_redis():


### PR DESCRIPTION
## Summary
- ensure MySQL inserts are committed in the voting example

## Testing
- `python3 -m py_compile list_timeline/main.py voting/main.py`
- `python3 -m py_compile stream_chat/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6843922f84108321ae84547746d91658