### PR TITLE
Fix stream_chat to work with Quart

### DIFF
--- a/stream_chat/templates/index.html
+++ b/stream_chat/templates/index.html
@@ -23,12 +23,12 @@
 
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js"></script>
     <script>
-      var was = null
+      var ws = null
       function joinRoom(event) {
         event.preventDefault();
-        if (was != null) ws.close();
+        if (ws != null) ws.close();
 
-        ws = new WebSocket('ws://127.0.0.1:8080/ws?' + $('join-info').serialize());
+        ws = new WebSocket('ws://127.0.0.1:8080/ws?' + $('#join-info').serialize());
         ws.onmessage = function(event) {
           $('#messages').append($('<li>').text(event.data));
           $('#messages').scrollTop($('#messages')[0].scrollHeight);


### PR DESCRIPTION
## Summary
- fix bugs in the chat WebSocket client HTML
- update server code to use Quart-style WebSocket handling
- add missing imports and run server on port 8080

## Testing
- `python -m py_compile stream_chat/main.py`
- `python stream_chat/main.py` *(fails: ModuleNotFoundError: No module named 'aioredis')*

------
https://chatgpt.com/codex/tasks/task_e_6848281417888321bc06616b911355b5