### PR TITLE
Document Redis structures in each example

### DIFF
--- a/list_timeline/README.md
+++ b/list_timeline/README.md
@@ -55,3 +55,19 @@ pip install 'flask[async]'
 ```zsh
  hypercorn main:app
 ```
+
+## Redisで利用している機能
+
+タイムラインはRedisの**List**で管理しています。新しい投稿を`RPUSH`で追加し、最新10件を`LRANGE`で取得します。さらに`EXPIRE`を設定して60秒で自動的に削除されるようにしています。
+
+例:
+
+```python
+# 投稿を追加
+await redis.rpush('timeline', 'user1: hello')
+await redis.expire('timeline', 60)
+
+# 最新10件を取得
+messages = await redis.lrange('timeline', 0, 9)
+```
+

--- a/stream_chat/README.md
+++ b/stream_chat/README.md
@@ -43,3 +43,18 @@ docker run -it --name chat_server -p 6379:6379 --rm redis
 - チャットルーム退室
 - チャットルーム入室通知
 - チャットルーム退室通知
+
+## Redisで利用している機能
+
+チャットメッセージはRedisの**Stream**を利用して保存しています。`XADD`でメッセージを追加し、`XREAD`でリアルタイムに取得します。ストリームの長さは`maxlen`オプションで制限しています。
+
+例:
+
+```python
+# メッセージの追加
+await redis.xadd(room, {"username": username, "msg": message}, id="*", maxlen=STREAM_MAX_LEN)
+
+# 新しいメッセージの取得
+events = await redis.xread({room: "$"})
+```
+

--- a/voting/README.md
+++ b/voting/README.md
@@ -54,3 +54,18 @@ docker run -it --name redis_server -p 6379:6379 --rm redis
 ```zsh
  poetry run python main.py
 ```
+
+## Redisで利用している機能
+
+投票情報はRedisの**Set**を用いて候補者ごとに投票者を記録しています。重複を防ぎ、`SCARD`で簡単に票数を数えることができます。
+
+例:
+
+```python
+# 候補者"alice"にuser1が投票
+await redis.sadd('candidate:alice', 'user1')
+
+# 投票数取得
+count = await redis.scard('candidate:alice')
+```
+


### PR DESCRIPTION
## Summary
- document the Redis structures used in `voting`
- document the Redis Stream usage for `stream_chat`
- document the List-based timeline implementation

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684e229469a48321ba74fdbd3e3a09e2